### PR TITLE
OpenFl : Fix - Slot pointer issue

### DIFF
--- a/src/msignal/Signal.hx
+++ b/src/msignal/Signal.hx
@@ -221,11 +221,15 @@ class Signal1<TValue> extends Signal<Slot1<TValue>, TValue -> Void>
 	public function dispatch(value:TValue)
 	{
 		var slotsToProcess = slots;
-		
-		while (slotsToProcess.nonEmpty)
+		if (slotsToProcess != null)
 		{
-			slotsToProcess.head.execute(value);
-			slotsToProcess = slotsToProcess.tail;
+			while (slotsToProcess.nonEmpty)
+			{
+				if (slotsToProcess.head != null)
+					slotsToProcess.head.execute(value);
+
+				slotsToProcess = slotsToProcess.tail;
+			}
 		}
 	}
 

--- a/src/msignal/Slot.hx
+++ b/src/msignal/Slot.hx
@@ -124,7 +124,7 @@ class Slot0 extends Slot<Signal0, Void -> Void>
 	{
 		if (!enabled) return;
 		if (once) remove();
-		listener();
+		if (listener != null) listener();
 	}
 }
 
@@ -152,7 +152,7 @@ class Slot1<TValue> extends Slot<Signal1<TValue>, TValue -> Void>
 		if (!enabled) return;
 		if (once) remove();
 		if (param != null) value1 = param;
-		listener(value1);
+		if (listener != null) listener(value1);
 	}
 }
 
@@ -189,6 +189,6 @@ class Slot2<TValue1, TValue2> extends Slot<Signal2<TValue1, TValue2>, TValue1 ->
 		if (param1 != null) value1 = param1;
 		if (param2 != null) value2 = param2;
 		
-		listener(value1, value2);
+		if (listener != null) listener(value1, value2);
 	}
 }


### PR DESCRIPTION
On OpenFl targets it seems than if a slot, or a slot reference is garbaged the value can be null and generate a SIGSEGV issue.
Add safeguard around the dispatch calls to ensure that either the list of slot to process, or the slot to be process is not null.

IOS Crash for reference:

```
Thread 0 Crashed:
0   Massivision                          0x008a2d6e msignal::Signal0_obj::dispatch() + 78
1   Massivision                          0x0091bd9d mui::display::Display_obj::__Field(String const&, bool) + 3650
2   Massivision                          0x007659ef mui::display::__DisplayRoot_objrenderFrame(hx::Object*, Dynamic const&) + 24
3   Massivision                          0x00937dad hx::CMemberFunction1::__run(Dynamic const&) + 10
4   Massivision                          0x006b4c1f openfl::_v2::events::Listener_obj::dispatchEvent(hx::ObjectPtr<openfl::_v2::events::Event_obj>) + 44
5   Massivision                          0x0085b281 openfl::_v2::events::EventDispatcher_obj::dispatchEvent(hx::ObjectPtr<openfl::_v2::events::Event_obj>) + 406
6   Massivision                          0x006e2499 openfl::_v2::display::DisplayObject_obj::__dispatchEvent(hx::ObjectPtr<openfl::_v2::events::Event_obj>) + 70
7   Massivision                          0x006e2329 openfl::_v2::display::DisplayObject_obj::__broadcast(hx::ObjectPtr<openfl::_v2::events::Event_obj>) + 18
8   Massivision                          0x006d2357 openfl::_v2::display::DisplayObjectContainer_obj::__broadcast(hx::ObjectPtr<openfl::_v2::events::Event_obj>) + 176
9   Massivision                          0x006bdf81 openfl::_v2::display::Stage_obj::__render(bool) + 146
10  Massivision                          0x006bac47 openfl::_v2::display::Stage_obj::__checkRender() + 104
11  Massivision                          0x006bafb1 openfl::_v2::display::Stage_obj::__doProcessStageEvent(Dynamic) + 838
12  Massivision                          0x006bb8e3 openfl::_v2::display::Stage_obj::__processStageEvent(Dynamic) + 24
13  Massivision                          0x006bb901 openfl::_v2::display::__Stage_obj__processStageEvent(hx::Object*, Dynamic const&) + 18
14  Massivision                          0x00937dad hx::CMemberFunction1::__run(Dynamic const&) + 10
15  Massivision                          0x00924dfd val_call1 + 110
```