### PR TITLE
fix: remove custom property accessors for haxe 4 support

### DIFF
--- a/src/msignal/Slot.hx
+++ b/src/msignal/Slot.hx
@@ -44,10 +44,10 @@ class Slot<TSignal:Signal<Dynamic, TListener>, TListener>
 	**/
 	#if cpp
 	#if haxe3 @:isVar #end
-	public var listener(get_listener, set_listener):TListener;
+	public var listener(get, set):TListener;
 	#else
 	#if haxe3 @:isVar #end
-	public var listener(default, set_listener):TListener;
+	public var listener(default, set):TListener;
 	#end
 	
 

--- a/src/msignal/SlotList.hx
+++ b/src/msignal/SlotList.hx
@@ -77,7 +77,7 @@ class SlotList<TSlot:Slot<Dynamic, Dynamic>, TListener>
 	/**
 		The number of slots in the list.
 	**/
-	public var length(get_length, null):Int;
+	public var length(get, null):Int;
 	function get_length():Int
 	{
 		if (!nonEmpty) return 0;


### PR DESCRIPTION
On Haxe version 4.0.0-preview.5+7eb789f54, this error appears: Custom property accessor is no longer supported, please use set. This should fix it.