### PR TITLE
Replacing deprecated Std.is with Std.isOfType

### DIFF
--- a/src/msignal/EventSignal.hx
+++ b/src/msignal/EventSignal.hx
@@ -99,7 +99,7 @@ class EventSignal<TTarget, TType>
 		{
 			currentTarget = Reflect.field(currentTarget, "parent");
 			
-			if (Std.is(currentTarget, EventDispatcher))
+			if (Std.isOfType(currentTarget, EventDispatcher))
 			{
 				event.currentTarget = currentTarget;
 				var dispatcher = cast(currentTarget, EventDispatcher<Dynamic>);

--- a/test/msignal/SignalTest.hx
+++ b/test/msignal/SignalTest.hx
@@ -291,7 +291,7 @@ class SignalTest
 	
 	function checkDate(date:Date):Void
 	{
-		Assert.isTrue(Std.is(date, Date));
+		Assert.isTrue(Std.isOfType(date, Date));
 	}
 	
 	@Test


### PR DESCRIPTION
Small change to get rid of the deprecation notices.